### PR TITLE
fix: add "SMBus is busy, can't use it" to DMESG_WHITELIST

### DIFF
--- a/mfd_dmesg/constants.py
+++ b/mfd_dmesg/constants.py
@@ -77,6 +77,7 @@ DMESG_WHITELIST = [
     r"Deprecated Driver is detected: bnx2i",
     r"the capability attribute has been deprecated",  # related to disk
     r"VF could not set VLAN 0",
+    r"SMBus is busy, can't use it",  # related to disk
 ]
 FAILS = ["no defer", "error", "fail", "timeout", "warning", "overruns", "excessive missed"]
 INVALID_MODULE_ERRORS = ["Invalid", "default value", "outside of range", "Single Root Input/Output Virtualization"]


### PR DESCRIPTION
This pull request introduces a minor update to the `OSPackageInfo` class in `mfd_dmesg/constants.py`, adding a new regular expression pattern to the list of deprecated messages. This change helps improve detection of deprecated hardware messages.

* Added the pattern `r"SMBus is busy, can't use it"` to the list of deprecated messages in `OSPackageInfo` to enhance identification of disk-related hardware issues.