### PR TITLE
feat: Add parameter for verify_messages to use optional custom dmesg …

### DIFF
--- a/mfd_dmesg/base.py
+++ b/mfd_dmesg/base.py
@@ -220,9 +220,10 @@ class Dmesg(ToolTemplate):
         else:
             return True
 
-    def verify_messages(self) -> dict:
+    def verify_messages(self, dmesg_whitelist: list[str] = DMESG_WHITELIST) -> dict:
         """Verify if there are err level messages in dmesg output.
 
+        :param dmesg_whitelist: list of benign messages to ignore
         :return: dictionary indicating success or failure and the error messages if present.
         """
         logger.log(level=log_levels.MODULE_DEBUG, msg="Verify Dmesg Errors.")
@@ -233,7 +234,7 @@ class Dmesg(ToolTemplate):
             for error in out.splitlines():
                 is_error = True
                 if self._check_specific_errors(error):
-                    for benign_message in DMESG_WHITELIST:
+                    for benign_message in dmesg_whitelist:
                         if benign_message in error:
                             is_error = False
                             logger.log(


### PR DESCRIPTION
This pull request updates the `verify_messages` method in `mfd_dmesg/base.py` to make the list of benign messages (the whitelist) configurable, improving flexibility for users who want to customize which dmesg messages are ignored. The most important changes are:

### Flexibility improvements

* Modified the `verify_messages` method to accept an optional `dmesg_whitelist` parameter, defaulting to `DMESG_WHITELIST`, allowing callers to specify a custom list of benign messages to ignore.
* Updated the internal logic of `verify_messages` to use the provided `dmesg_whitelist` parameter instead of the hardcoded `DMESG_WHITELIST` variable when checking for benign messages.